### PR TITLE
Added missing recipes for Pam's HarvestCraft 2

### DIFF
--- a/kubejs/data/pamhc2foodextended/recipes/bangersandmashitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/bangersandmashitem.json
@@ -1,0 +1,21 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_skillet"
+    },
+	{	
+      "tag": "forge:sausage"
+    },
+	{	
+      "item": "pamhc2foodcore:mashedpotatoesitem"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:bangersandmashitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/bbqchickenbiscuititem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/bbqchickenbiscuititem.json
@@ -1,0 +1,24 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_cuttingboard"
+    },
+	{	
+      "item": "pamhc2foodcore:friedchickenitem"
+    },
+	{	
+      "item": "pamhc2foodextended:biscuititem"
+    },
+	{	
+      "tag": "forge:condiments/bbqsauce"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:bbqchickenbiscuititem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/bulgogiitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/bulgogiitem.json
@@ -1,0 +1,33 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_skillet"
+    },
+	{	
+      "tag": "forge:rawbeef"
+    },
+	{	
+      "tag": "forge:crops/garlic"
+    },
+	{	
+      "tag": "forge:condiments/soysauce"
+    },
+	{	
+      "tag": "forge:sugar"
+    },
+	{	
+      "tag": "forge:spices/blackpepper"
+    },
+	{	
+      "tag": "forge:crops/scallion"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:bulgogiitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/curryitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/curryitem.json
@@ -1,0 +1,30 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_saucepan"
+    },
+	{	
+      "tag": "forge:crops/rice"
+    },
+	{	
+      "tag": "forge:spices/blackpepper"
+    },
+	{	
+      "tag": "forge:crops/chilipepper"
+    },
+	{	
+      "tag": "forge:crops/coconut"
+    },
+	{	
+      "tag": "forge:spices/currypowder"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:curryitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/earlgreyteaitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/earlgreyteaitem.json
@@ -1,0 +1,21 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_pot"
+    },
+	{	
+      "tag": "forge:crops/tealeaf"
+    },
+	{	
+      "tag": "forge:crops/orange"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:earlgreyteaitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/gourmetmuttonpattyitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/gourmetmuttonpattyitem.json
@@ -1,0 +1,27 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_mixingbowl"
+    },
+	{	
+      "tag": "forge:groundmeats/groundmutton"
+    },
+	{	
+      "tag": "forge:spices/saltandpepper"
+    },
+	{	
+      "tag": "forge:crops/spiceleaf"
+    },
+	{	
+      "tag": "forge:crops/mustardseeds"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:gourmetmuttonpattyitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/gourmetporkburgeritem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/gourmetporkburgeritem.json
@@ -1,0 +1,33 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_skillet"
+    },
+	{	
+      "item": "pamhc2foodextended:gourmetporkpattyitem"
+    },
+	{	
+      "item": "pamhc2foodextended:briochebunitem"
+    },
+	{	
+      "tag": "forge:crops/tomato"
+    },
+	{	
+      "tag": "forge:leafyvegetables"
+    },
+	{	
+      "tag": "forge:crops/avocado"
+    },
+	{	
+      "item": "pamhc2foodextended:friedonionsitem"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:gourmetporkburgeritem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/groundnutmegitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/groundnutmegitem.json
@@ -1,0 +1,18 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_grinder"
+    },
+	{	
+      "tag": "forge:crops/nutmeg"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:groundnutmegitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/leafyfishsandwichitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/leafyfishsandwichitem.json
@@ -1,0 +1,21 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_cuttingboard"
+    },
+	{	
+      "tag": "pamhc2foodcore:basicfishsandwichitem"
+    },
+	{	
+      "tag": "forge:leafyvegetables"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:leafyfishsandwichitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/mochicakeitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/mochicakeitem.json
@@ -1,0 +1,33 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_bakeware"
+    },
+	{	
+      "tag": "forge:butter"
+    },
+	{	
+      "item": "pamhc2foodextended:mochiitem"
+    },
+	{	
+      "tag": "forge:flour"
+    },
+	{	
+      "tag": "forge:egg"
+    },
+	{	
+      "tag": "forge:spices/vanilla"
+    },
+	{	
+      "tag": "forge:milk"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:mochicakeitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/peachesandcreamoatmealitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/peachesandcreamoatmealitem.json
@@ -1,0 +1,28 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_pot"
+    },
+    {
+      "tag": "forge:crops/oats"
+    },
+    {
+      "tag": "forge:crops/peach"
+    },
+	{
+      "tag": "forge:cream"
+    },
+	{
+      "tag": "forge:water"
+    }
+
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:peachesandcreamoatmealitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/raspberrytrifleitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/raspberrytrifleitem.json
@@ -1,0 +1,27 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_bakeware"
+    },
+	{	
+      "tag": "forge:crops/raspberry"
+    },
+	{	
+      "tag": "forge:cream"
+    },
+	{	
+      "tag": "forge:spices/vanilla"
+    },
+	{	
+      "tag": "forge:dough"
+    }
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:raspberrytrifleitem",
+	"count": 1}
+	
+}

--- a/kubejs/data/pamhc2foodextended/recipes/rawtofishitem.json
+++ b/kubejs/data/pamhc2foodextended/recipes/rawtofishitem.json
@@ -1,0 +1,25 @@
+{
+	"type": "minecraft:crafting_shapeless",
+	
+	"ingredients":
+	[
+    {
+      "tag": "forge:tool_mixingbowl"
+    },
+    {
+      "tag": "forge:firmtofu"
+    },
+	{
+	"tag": "forge:condiments/soysauce"
+	},
+	{
+	"item": "minecraft:kelp"
+	}
+
+
+	],
+	
+	"result": {"item": "pamhc2foodextended:rawtofishitem",
+	"count": 2}
+	
+}


### PR DESCRIPTION
Pam's HarvestCraft 1.16.x has missing recipes for some of its items.  However, that version of the mod is no longer being maintained and will no longer see mod updates.  A kubejs pack was released to add the missing recipes.  Tested and confirmed to work with Ultimate Progression.