### PR TITLE
Added Goblin Trader and Red Merchant to NoMoWanderer watch list

### DIFF
--- a/config/nomowanderer-common.toml
+++ b/config/nomowanderer-common.toml
@@ -1,0 +1,8 @@
+#A list of modid:entity_name entries that will be blocked from spawning.
+entityBlockList = ["minecraft:wandering_trader", "rats:plague_doctor", "goblintraders:goblin_trader", "supplementaries:red_merchant"]
+#Entity spawn prevention radius (in chunks)
+#Range: 4 ~ 12
+radius = 8
+#Disable all spawns of entities in entityBlockList?
+disableSpawns = false
+


### PR DESCRIPTION
This was a contribution I made to another pack and it functioned as expected.  The Goblin Trader spawns often in the base.  Once you have progressed far enough into the game, the goblin trader isn't useful anymore.  The Red Merchant is included because it will also (very rarely) spawn at the base and belongs in the same category as the other traders.  

This config change adds both the Goblin Trader and the Red Merchant to the watchlist for the NoMoWanderer anti-soliciting items to allow the same control over them as it has over the Wandering Trader and Plague Doctor.